### PR TITLE
Modified behavior for checkedValue changes in DotVVM checkboxes

### DIFF
--- a/src/binding/defaultBindings/checked.js
+++ b/src/binding/defaultBindings/checked.js
@@ -50,7 +50,10 @@ ko.bindingHandlers['checked'] = {
                     // When we're responding to the checkedValue changing, and the element is
                     // currently checked, replace the old elem value with the new elem value
                     // in the model array.
-                    if (isChecked) {
+                    if (isChecked
+                        // we want to suppress this behavior in DotVVM - it will applies only to non-DotVVM checkboxes
+                        && !allBindings['has']('checkedArrayContainsObservables')
+                    ) {
                         ko.utils.addOrRemoveItem(writableValue, elemValue, true, checkedArrayContainsObservables, checkedValueComparer);
                         ko.utils.addOrRemoveItem(writableValue, saveOldValue, false, checkedArrayContainsObservables, checkedValueComparer);
                     }


### PR DESCRIPTION
I changed the behavior of the checkedValue binding for checkboxes in DotVVM (those with the checkedArrayContainsObservables binding).

When the checkbox is checked, and its checkedValue is updated, Knockout has updated the value in the checkedItems collection to keep the checkbox checked.
This doesn't work well when we use checkboxes in foreach bindings, for example, in combination with paging. When the user switches to another page, and memoization is used (the checkboxes will stay on the page, just getting the new checkedValue), we want to keep the checkedItems collection as it was, and have the checkboxes reflecting its state.

If someone needs the default Knockout behavior, they will need to replace the values in the checkedItems collection on their own (when changing the checkedValue).